### PR TITLE
fix: corregir error de electron-updater en Windows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,11 +24,15 @@
     "appId": "com.dailyplanner.app",
     "productName": "Daily Planner",
     "copyright": "Copyright © 2024 Victor",
+    "asar": true,
     "files": [
       "build/**/*",
       "public/electron.js",
       "public/icon.png",
-      "public/icon.ico"
+      "public/icon.ico",
+      "node_modules/electron-updater/**/*",
+      "node_modules/lazy-val/**/*",
+      "node_modules/semver/**/*"
     ],
     "extraResources": [
       {


### PR DESCRIPTION
## 🐛 Corrección

### Problema
El ejecutable de Windows (.exe) fallaba al iniciar con el error:
```
Cannot find module 'electron-updater'
```

### Solución
1. **package.json**: Añadido `electron-updater` y dependencias a la lista de `files` del build
2. **electron.js**: Importación segura con try-catch para que la app funcione aunque el módulo no esté disponible
3. Todas las referencias a `autoUpdater` ahora verifican null antes de usarlo

### Archivos modificados
- `client/package.json`
- `client/public/electron.js`

### Testing
- ✅ Build de Linux (AppImage) funciona correctamente
- ✅ Build de Windows (exe) funciona correctamente